### PR TITLE
Исправление E_WARNING при FOLLOWLOCATION

### DIFF
--- a/core/components/swift/model/openstack/cloudfiles_http.php
+++ b/core/components/swift/model/openstack/cloudfiles_http.php
@@ -245,7 +245,9 @@ class CF_Http
             curl_setopt($curl_ch, CURLOPT_CAINFO, $this->cabundle_path);
         }
         curl_setopt($curl_ch, CURLOPT_VERBOSE, $this->dbug);
-        curl_setopt($curl_ch, CURLOPT_FOLLOWLOCATION, 1);
+        if (empty(ini_get('open_basedir')) && empty(ini_get('safe_mode'))) {
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+        }
         curl_setopt($curl_ch, CURLOPT_MAXREDIRS, 4);
         curl_setopt($curl_ch, CURLOPT_HEADER, 0);
         curl_setopt($curl_ch, CURLOPT_HTTPHEADER, $headers);
@@ -1350,8 +1352,10 @@ class CF_Http
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, True);
             curl_setopt($ch, CURLOPT_CAINFO, $this->cabundle_path);
         }
-	curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, True);
-        curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, True);
+        if (empty(ini_get('open_basedir')) && empty(ini_get('safe_mode'))) {
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
+        }
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
         curl_setopt($ch, CURLOPT_MAXREDIRS, 4);
         curl_setopt($ch, CURLOPT_HEADER, 0);


### PR DESCRIPTION
Исправление E_WARNING в логах на хостингах с включенными open_basedir или safe_mode.

```
PHP warning: curl_setopt(): CURLOPT_FOLLOWLOCATION cannot be activated when an open_basedir is set
```
